### PR TITLE
I messed up, and then fixed it.

### DIFF
--- a/src/main/java/org/livoniawarriors/Robot2019/subsystems/gameplay/Elevator.java
+++ b/src/main/java/org/livoniawarriors/Robot2019/subsystems/gameplay/Elevator.java
@@ -130,13 +130,11 @@ public class Elevator implements PIDSource, PIDOutput, IDiagnosable {
 	public void diagnose() {
 		double testElevHeight = getElevatorHeight();
 		if(testElevHeight >= 0 && testElevHeight <= 100) {
-			System.out.println("Method getElevatorHeight() is reported as a success with the value of " 
-			  + Double.toString(testElevHeight));
+			System.out.println("Method getElevatorHeight() is reported as a success with the value of " + testElevHeight);
 			Robot.logger.log(Level.ERROR, 
 			  String.format("Method getElevatorHeight() returned value {0} and did not detect failure", testElevHeight));
 		} else {
-			System.out.println("Method getElevatorHeight() is reported as a failure with the value of "
-			  + Double.toString(testElevHeight));
+			System.out.println("Method getElevatorHeight() is reported as a failure with the value of " + testElevHeight);
 			Robot.logger.log(Level.ERROR, 
 			  String.format("Method getElevatorHeight() returned value {0} and DETECTED FAILURE!!!", testElevHeight));
 		}


### PR DESCRIPTION
Doubles are automatically converted to strings, as I have recently been informed, in a strange lack of complication.  Now, it should print something instead of returning null.